### PR TITLE
Support for building as subdirectory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,37 @@
 cmake_minimum_required (VERSION 3.12)
 project (thesis)
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+# project options, used to control separate actions in the build configuration
+option (THESIS_BUILD_EXAMPLES "Build examples for the project." OFF)
+option (THESIS_TLSE_UNIT_TESTS "Build unit tests for the project." ON)
+option (THESIS_BUILD_MONGOOSE "Enable or Disable thesis to build mongoose." ON)
+option (THESIS_BUILD_AS_LIBRARY "Build library without linking against mongoose." OFF)
+
+# build_mongoose and build_as_library is the same?
+# build_as_lib is meant as parameter to disable any linkage to
+# mongoose for example. perhaps it's easier to understand if
+# user wants to link against
+
+if (${THESIS_BUILD_AS_LIBRARY})
+    set (THESIS_BUILD_MONGOOSE FALSE)
+endif ()
+
+message ("Thesis building mongoose : ${THESIS_BUILD_MONGOOSE}")
+
+list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set (THESIS_MG_ARCH "1") # 1 == LINUX, immediate value, set from var instead?
+# definitions required to compile against custom tls implementation.
+# is mongoose enough?
+set (THESIS_MG_DEFINITIONS
+    MG_ARCH=${THESIS_MG_ARCH}
+    MG_ENABLE_TLSE
+    MG_ENABLE_CUSTOM_TLS)
 
 set (THESIS_TLS_SOURCES
     src/tls_tlse.h
     src/tls_tlse.c)
-
 
 add_subdirectory (deps)
 
@@ -15,33 +39,36 @@ add_subdirectory (deps)
 # crypto functionalities provided by tomcrypt.
 add_library (thesis-tls ${THESIS_TLS_SOURCES})
 
-
-# Add includes for the libtlse, mongoose and tlse from deps folder.
+# add includes for the libtlse, mongoose and tlse from deps folder.
 target_include_directories(thesis-tls
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/mongoose>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/mongoose/src>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/tlse>)
 
-# Definitions required to compile against custom tls implementation.
-set (MG_DEFINITIONS
-        MG_ARCH=${MG_ARCH}
-        MG_ENABLE_TLSE
-        MG_ENABLE_CUSTOM_TLS)
-
 target_compile_definitions(thesis-tls
     PUBLIC
-    ${MG_DEFINITIONS})
+        ${THESIS_MG_DEFINITIONS})
 
 target_link_libraries(thesis-tls
     PRIVATE
         tlse)
 
-# Build the examples
-set (THESIS_TLSE_EXAMPLES   TRUE)
-set (THESIS_TLSE_UNIT_TESTS TRUE)
+target_link_libraries (thesis-tls
+    PRIVATE mongoose)
 
-# Enable testing, including the dependencies.
+# build the examples
+# set (TRUE)
+
+# should wokr
+# if (${THESIS_BUILD_AS_LIBRARY})
+#     message ("Building thesis as subdirectory.")
+#     message ("Disabling examples and unit tests.")
+#     set (THESIS_TLSE_EXAMPLES   FALSE)
+#     set (THESIS_TLSE_UNIT_TESTS FALSE)
+# endif ()
+
+# enable testing, including the dependencies.
 if (THESIS_TLSE_UNIT_TESTS)
     enable_testing()
 

--- a/cmake/certificates.cmake
+++ b/cmake/certificates.cmake
@@ -1,4 +1,8 @@
-# Test certificates
+
+# if the thesis is added as subdirectory,
+# how to correctly resolve the copying process,
+# even if it's called from a different root folder,
+# ${THESIS_PROJECT_DIR}
 set (THESIS_TEST_CERTIFICATES
     "tests/certs/ca.pem"
     "tests/certs/cert-2048.pem"
@@ -9,14 +13,29 @@ set (THESIS_TEST_CERTIFICATES
 
 include (functions)
 
+# can be set outside of certificates to control the subdir name
+set (THESIS_PROJECT_FOLDER_NAME "thesis")
+
 # @fn thesis_copy_certificates
 # @param TARGET_NAME target name
 # Target is required as the copy command is added
 # to the POST_BUILD process.
 function (thesis_copy_certificates TARGET_NAME)
+    # build_as_library defined out of scope.
+    message ("copy_certs : ${THESIS_BUILD_AS_LIBRARY}")
+
     foreach (FILE_INPUT IN LISTS THESIS_TEST_CERTIFICATES)
-        # Remove the tests/ from the output folder naming.
-        string (REPLACE "tests/" "" FILE_CERT ${FILE_INPUT})
-        thesis_copy_build (${TARGET_NAME} ${FILE_INPUT} ${FILE_CERT})
+        set (THESIS_FILE_INPUT "${FILE_INPUT}")
+        set (THESIS_FILE_REGEX "tests/")
+
+        # append the project_folder_name if built as library.
+        if (${THESIS_BUILD_AS_LIBRARY})
+            set (THESIS_FILE_INPUT "${THESIS_PROJECT_FOLDER_NAME}/${FILE_INPUT}")
+            set (THESIS_FILE_REGEX "thesis/tests")
+        endif ()
+
+        # remove the tests/ from the output folder naming.
+        string (REPLACE ${THESIS_FILE_REGEX} "" FILE_CERT ${FILE_INPUT})
+        thesis_copy_build (${TARGET_NAME} ${THESIS_FILE_INPUT} ${FILE_CERT})
     endforeach ()
 endfunction ()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -1,17 +1,41 @@
+# CMake configuration for the dependencies.
+# Dependencies include, tlse, mongoose, check, tomcrypt.
+# Velho
+
+# set (BUILD_TLSE_EXAMPLES TRUE)
+
 # Define the build definitions.
 # MG_ARCH Initialized with a value
 # MG_ENABLE_CUSTOM_TLS
 # MG_ENABLE_TLSE
 
-set (MG_ARCH_CUSTOM "0")
-set (MG_ARCH_UNIX "1")
-set (MG_ARCH_WIN32 "2")
-set (MG_ARCH ${MG_ARCH_UNIX} PARENT_SCOPE) #
+if (${THESIS_BUILD_MONGOOSE})
+    message ("Building thesis as part of thesis library.")
 
-file (GLOB MONGOOSE_SOURCES
-    mongoose/src/*.h
-    mongoose/src/*.c)
+    file (GLOB MONGOOSE_SOURCES
+        mongoose/src/*.h
+        mongoose/src/*.c)
 
+    add_library (mongoose   ${MONGOOSE_SOURCES})
+
+    target_include_directories(mongoose
+        PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+    target_compile_definitions(mongoose
+        PUBLIC
+            ${THESIS_MG_DEFINITIONS})
+
+
+    set (MONGOOSE_INCLUDE_DIR
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/mongoose>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/mongoose/src>
+        PARENT_SCOPE)
+
+    target_link_libraries(mongoose
+        PRIVATE
+            thesis-tls)
+endif ()
 
 set (TLSE_SOURCES
     tlse/curve25519.c
@@ -19,31 +43,15 @@ set (TLSE_SOURCES
     tlse/tlse.h
     tlse/tlse.c)
 
-
-
 add_library (tlse       ${TLSE_SOURCES})
-add_library (mongoose   ${MONGOOSE_SOURCES})
-
-target_include_directories(mongoose
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/src)
-
-target_compile_definitions(mongoose
-    PUBLIC
-    ${MG_DEFINITIONS})
 
 target_compile_definitions(tlse
     PUBLIC
         TLS_AMALGAMATION
         DEBUG)
 
-target_link_libraries(mongoose
-    PRIVATE
-        thesis-tls)
 
-set (BUILD_TLSE_EXAMPLES TRUE)
-
-if (${BUILD_TLSE_EXAMPLES})
+if (THESIS_TLSE_EXAMPLES EQUAL TRUE)
     include (certificates)
 
     set (TLSE_EXAMPLE_HW_SOURCES tlse/examples/tlshelloworld.c)
@@ -57,5 +65,5 @@ if (${BUILD_TLSE_EXAMPLES})
         PRIVATE
             DEBUG)
 
-    thesis_copy_certificates ("tls-helloworld")
+    thesis_copy_certificates (tls-helloworld)
 endif ()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,18 +8,15 @@ set (THESIS_TLS_SERVER_SRC
 add_executable (${THESIS_EX1}
     ${THESIS_TLS_SERVER_SRC})
 
-
 # Link against thesis-tls, (required to link against mongoose as well??)
 target_link_libraries (${THESIS_EX1}
     PRIVATE
-        thesis-tls tlse mongoose
-)
+        thesis-tls tlse mongoose)
 
 # Add include headers for the mongoose target
 target_include_directories (${THESIS_EX1}
     PRIVATE
-        thesis-tls mongoose
-)
+        thesis-tls mongoose)
 
 set (TARGET_NAME ${THESIS_EX1})
 include (certificates)


### PR DESCRIPTION
Project can be included and mongoose can be provided separately. Adding new configuration variables to fine control the build, excluding the different parts which are not necessary. Build as library is aggregating parameter to disable the others(mg, unit tests and examples).
Fixed the certificate to correctly manage if calling from a different root directory, if the project folder name is different, THESIS_PROJECT_FOLDER_NAME can be used to set it correctly.